### PR TITLE
Uncomment and array_append don't play along

### DIFF
--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -194,9 +194,9 @@ Puppet::Type.type(:shellvar).provide(:augeas, :parent => Puppet::Type.type(:auge
       commented_values = []
       if ! commented.empty?
         if aug.get(commented.first).include?('=')
-          commented_values = aug.get(commented.first).split('=')[1].split(' ')
+          commented_values = unquoteit(aug.get(commented.first).split('=')[1]).split(' ')
         else
-          commented_values = aug.get(commented.first).split(' ')
+          commented_values = unquoteit(aug.get(commented.first)).split(' ')
         end
       end
       comment_ins = '$resource'
@@ -222,7 +222,7 @@ Puppet::Type.type(:shellvar).provide(:augeas, :parent => Puppet::Type.type(:auge
             values = commented_values
           elsif resource[:array_append]
             # value is provided and merge requested
-            values = commented_values.map { |v| unquoteit(v) } | resource[:value]
+            values = commented_values | resource[:value]
           else
             # value is provided and replacement requested
             values = resource[:value]

--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -216,8 +216,17 @@ Puppet::Type.type(:shellvar).provide(:augeas, :parent => Puppet::Type.type(:auge
           aug.insert(commented.first, resource[:variable], false)
           aug.rm(commented.first) if resource[:uncomment] == :true
         end
-        if resource[:value].nil? && resource[:uncomment] == :true
-          values = commented_values
+        if resource[:uncomment] == :true
+          if resource[:value].nil?
+            # value is not provided
+            values = commented_values
+          elsif resource[:array_append]
+            # value is provided and merge requested
+            values = commented_values.map { |v| unquoteit(v) } | resource[:value]
+          else
+            # value is provided and replacement requested
+            values = resource[:value]
+          end
         else
           values = resource[:value]
         end

--- a/spec/fixtures/unit/puppet/provider/shellvar/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/shellvar/augeas/full
@@ -10,6 +10,7 @@ RETRIES=2
 #SYNC_HWCLOCK=no
 
 #LS_JAVA_OPTS="option1"
+#LS_JAVA_OPTS_MULT="option1 option2"
 
 EXAMPLE=foo
 

--- a/spec/fixtures/unit/puppet/provider/shellvar/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/shellvar/augeas/full
@@ -9,6 +9,8 @@ RETRIES=2
 # Set to 'yes' to sync hw clock after successful ntpdate
 #SYNC_HWCLOCK=no
 
+#LS_JAVA_OPTS="option1"
+
 EXAMPLE=foo
 
 unset EXAMPLE_U

--- a/spec/unit/puppet/provider/shellvar/augeas_spec.rb
+++ b/spec/unit/puppet/provider/shellvar/augeas_spec.rb
@@ -248,19 +248,34 @@ describe provider_class do
     end
 
 	it "should uncomment value and append" do
-		apply!(Puppet::Type.type(:shellvar).new(
-			:name         => "LS_JAVA_OPTS",
-			:value        => ["option2", "option3"],
-			:array_append => true,
-			:uncomment    => true,
-			:target       => target,
-			:provider     => "augeas"
-		))
+      apply!(Puppet::Type.type(:shellvar).new(
+        :name         => "LS_JAVA_OPTS",
+        :value        => ["option2", "option3"],
+        :array_append => true,
+        :uncomment    => true,
+        :target       => target,
+        :provider     => "augeas"
+      ))
 
-		augparse_filter(target, "Shellvars.lns", "LS_JAVA_OPTS", '
-		   { "LS_JAVA_OPTS" = "\"option1 option2 option3\"" }
-						')
-	end
+      augparse_filter(target, "Shellvars.lns", "LS_JAVA_OPTS", '
+        { "LS_JAVA_OPTS" = "\"option1 option2 option3\"" }
+      ')
+    end
+
+	it "should uncomment values and append" do
+      apply!(Puppet::Type.type(:shellvar).new(
+        :name         => "LS_JAVA_OPTS_MULT",
+        :value        => ["option2", "option3"],
+        :array_append => true,
+        :uncomment    => true,
+        :target       => target,
+        :provider     => "augeas"
+      ))
+
+      augparse_filter(target, "Shellvars.lns", "LS_JAVA_OPTS_MULT", '
+        { "LS_JAVA_OPTS_MULT" = "\"option1 option2 option3\"" }
+      ')
+    end
 
     describe "when updating value" do
       it "should change unquoted value" do

--- a/spec/unit/puppet/provider/shellvar/augeas_spec.rb
+++ b/spec/unit/puppet/provider/shellvar/augeas_spec.rb
@@ -182,34 +182,8 @@ describe provider_class do
         :provider => "augeas"
       ))
 
-      if unset_seq?
-        augparse_filter(target, "Shellvars.lns", '*[preceding-sibling::#comment[.=~regexp(".*sync hw clock.*")]]', '
-          { "#comment" = "SYNC_HWCLOCK=no" }
-          { "SYNC_HWCLOCK" = "yes" }
-          { "EXAMPLE" = "foo" }
-          { "@unset" { "1" = "EXAMPLE_U" } }
-          { "EXAMPLE_E" = "baz" { "export" } }
-          { "STR_LIST" = "\"foo bar baz\"" }
-          { "LST_LIST"
-            { "1" = "foo" }
-            { "2" = "\"bar baz\"" }
-            { "3" = "123" }
-          }
-        ')
-      else
-        augparse_filter(target, "Shellvars.lns", '*[preceding-sibling::#comment[.=~regexp(".*sync hw clock.*")]]', '
-          { "#comment" = "SYNC_HWCLOCK=no" }
-          { "SYNC_HWCLOCK" = "yes" }
-          { "EXAMPLE" = "foo" }
-          { "@unset" = "EXAMPLE_U" }
-          { "EXAMPLE_E" = "baz" { "export" } }
-          { "STR_LIST" = "\"foo bar baz\"" }
-          { "LST_LIST"
-            { "1" = "foo" }
-            { "2" = "\"bar baz\"" }
-            { "3" = "123" }
-          }
-        ')
+      aug_open(target, "Shellvars.lns") do |aug|
+        aug.get("SYNC_HWCLOCK[preceding-sibling::#comment[.='SYNC_HWCLOCK=no']]").should == "yes"
       end
     end
 
@@ -222,32 +196,8 @@ describe provider_class do
         :provider  => "augeas"
       ))
 
-      if unset_seq?
-        augparse_filter(target, "Shellvars.lns", '*[preceding-sibling::#comment[.=~regexp(".*sync hw clock.*")]]', '
-          { "SYNC_HWCLOCK" = "yes" }
-          { "EXAMPLE" = "foo" }
-          { "@unset" { "1" = "EXAMPLE_U" } }
-          { "EXAMPLE_E" = "baz" { "export" } }
-          { "STR_LIST" = "\"foo bar baz\"" }
-          { "LST_LIST"
-            { "1" = "foo" }
-            { "2" = "\"bar baz\"" }
-            { "3" = "123" }
-          }
-        ')
-      else
-        augparse_filter(target, "Shellvars.lns", '*[preceding-sibling::#comment[.=~regexp(".*sync hw clock.*")]]', '
-          { "SYNC_HWCLOCK" = "yes" }
-          { "EXAMPLE" = "foo" }
-          { "@unset" = "EXAMPLE_U" }
-          { "EXAMPLE_E" = "baz" { "export" } }
-          { "STR_LIST" = "\"foo bar baz\"" }
-          { "LST_LIST"
-            { "1" = "foo" }
-            { "2" = "\"bar baz\"" }
-            { "3" = "123" }
-          }
-        ')
+      aug_open(target, "Shellvars.lns") do |aug|
+        aug.get("SYNC_HWCLOCK").should == "yes"
       end
     end
 
@@ -260,32 +210,8 @@ describe provider_class do
         :provider  => "augeas"
       ))
 
-      if unset_seq?
-        augparse_filter(target, "Shellvars.lns", '*[preceding-sibling::#comment[.=~regexp(".*sync hw clock.*")]]', '
-          { "SYNC_HWCLOCK" = "no" }
-          { "EXAMPLE" = "foo" }
-          { "@unset" { "1" = "EXAMPLE_U" } }
-          { "EXAMPLE_E" = "baz" { "export" } }
-          { "STR_LIST" = "\"foo bar baz\"" }
-          { "LST_LIST"
-            { "1" = "foo" }
-            { "2" = "\"bar baz\"" }
-            { "3" = "123" }
-          }
-        ')
-      else
-        augparse_filter(target, "Shellvars.lns", '*[preceding-sibling::#comment[.=~regexp(".*sync hw clock.*")]]', '
-          { "SYNC_HWCLOCK" = "no" }
-          { "EXAMPLE" = "foo" }
-          { "@unset" = "EXAMPLE_U" }
-          { "EXAMPLE_E" = "baz" { "export" } }
-          { "STR_LIST" = "\"foo bar baz\"" }
-          { "LST_LIST"
-            { "1" = "foo" }
-            { "2" = "\"bar baz\"" }
-            { "3" = "123" }
-          }
-        ')
+      aug_open(target, "Shellvars.lns") do |aug|
+        aug.get("SYNC_HWCLOCK").should == "no"
       end
     end
 
@@ -320,6 +246,21 @@ describe provider_class do
         end
       end
     end
+
+	it "should uncomment value and append" do
+		apply!(Puppet::Type.type(:shellvar).new(
+			:name         => "LS_JAVA_OPTS",
+			:value        => ["option2", "option3"],
+			:array_append => true,
+			:uncomment    => true,
+			:target       => target,
+			:provider     => "augeas"
+		))
+
+		augparse_filter(target, "Shellvars.lns", "LS_JAVA_OPTS", '
+		   { "LS_JAVA_OPTS" = "\"option1 option2 option3\"" }
+						')
+	end
 
     describe "when updating value" do
       it "should change unquoted value" do


### PR DESCRIPTION
```
shellvar { "sysconfig_logstash":
  ensure       => present,
  target       => '/etc/sysconfig/logstash',
  uncomment    => true,
  variable     => 'LS_JAVA_OPTS'
  value        => ["option2", "option3"],
  array_append => true,
}
```

This uncomments the line, but overrides the content instead of appending.
Provided that `/etc/sysconfig/logstash` had line:

```
# LS_JAVA_OPTS = "option1"
```

after running puppet I'd like to get:

```
LS_JAVA_OPTS = "option1 option2 option3"
```

but in reality I get:

```
LS_JAVA_OPTS = "option2 option3"
```