### PR TITLE
New define: augeasproviders_shellvar::bulk

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ values themselves.
       uncomment => true,
     }
 
+### set many variables in the same file
+
+    augeasproviders_shellvar::bulk { [
+        'DEVICE=eth0',
+        'NAME=eth0',
+        "HWADDR=${hwaddress}",
+      ]: 
+      target => '/etc/sysconfig/network',
+    }
+
 ### array values
 
 You can pass array values to the type.

--- a/manifests/bulk.pp
+++ b/manifests/bulk.pp
@@ -1,0 +1,20 @@
+#
+define augeasproviders_shellvar::bulk (
+  $target,
+  $quoted = undef,
+) {
+
+    $arr = split($name, '=')
+    $k = $arr[0]
+    $v = $arr[1]
+
+    shellvar { "${target} ${k}":
+      ensure   => present,
+      variable => $k,
+      value    => $v,
+      target   => $target,
+      quoted   => $quoted,
+    }
+
+
+}

--- a/spec/defines/bulk_spec.rb
+++ b/spec/defines/bulk_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'augeasproviders_shellvar::bulk' do
+
+  describe 'default options' do
+    let(:title) { 'thekey=thevalue' }
+    let(:params) {{
+      :target => '/tmp/test.txt',
+    }}
+    it { should compile }
+    it { should contain_shellvar('/tmp/test.txt thekey').with(
+      :ensure        => 'present',
+      :variable      => 'thekey',
+      :value         => 'thevalue',
+      :target        => '/tmp/test.txt',
+      :quoted        => nil
+    )}
+  end
+
+  describe 'with double-quotes enabled' do
+    let(:title) { 'thekey=thevalue' }
+    let(:params) {{
+      :target => '/tmp/test.txt',
+      :quoted => 'double',
+    }}
+    it { should compile }
+    it { should contain_shellvar('/tmp/test.txt thekey').with(
+      :ensure        => 'present',
+      :variable      => 'thekey',
+      :value         => 'thevalue',
+      :target        => '/tmp/test.txt',
+      :quoted        => 'double',
+    )}
+  end
+
+end


### PR DESCRIPTION
This fixes https://github.com/hercules-team/augeasproviders_shellvar/issues/14

It is ugly to have augeasproviders_shellvar::bulk instead of shellvar::bulk but it isn't obvious to me how to give it that name and have autoload work.  Suggestions?