### PR TITLE
Break the broken fixture again

### DIFF
--- a/spec/fixtures/unit/puppet/provider/shellvar/augeas/broken
+++ b/spec/fixtures/unit/puppet/provider/shellvar/augeas/broken
@@ -1,5 +1,5 @@
 # Options for ntpdate
-OPTIONS = "-p 2"
+[ OPTIONS = "-p 2"
 
 # Number of retries before giving up
 RETRIES=2


### PR DESCRIPTION
The new Shellvars.lns lens allows to generic commands syntax.
For this reason, the current broken fixture is not broken anymore.
This commits breaks it again, better.