### PR TITLE
Fix commented out variables with no assigned value causing an error

### DIFF
--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -190,7 +190,15 @@ Puppet::Type.type(:shellvar).provide(:augeas, :parent => Puppet::Type.type(:auge
     augopen! do |aug|
       # Prefer to create the node next to a commented out entry
       commented = aug.match("$target/#comment[.=~regexp('#{resource[:variable]}([^a-z\.].*)?')]")
-      commented_values = commented.empty? ? [] : aug.get(commented.first).split('=')[1].split(' ')
+
+      commented_values = []
+      if ! commented.empty?
+        if aug.get(commented.first).include?('=')
+          commented_values = aug.get(commented.first).split('=')[1].split(' ')
+        else
+          commented_values = aug.get(commented.first).split(' ')
+        end
+      end
       comment_ins = '$resource'
 
       if resource[:ensure] == :unset

--- a/spec/fixtures/unit/puppet/provider/shellvar/augeas/commented
+++ b/spec/fixtures/unit/puppet/provider/shellvar/augeas/commented
@@ -1,0 +1,1 @@
+# UMASK sets the initial shell file creation mode mask.  See umask(1).

--- a/spec/unit/puppet/provider/shellvar/augeas_spec.rb
+++ b/spec/unit/puppet/provider/shellvar/augeas_spec.rb
@@ -697,7 +697,7 @@ describe provider_class do
             augparse_filter(target, "Shellvars.lns", "ML_LIST", '
               { "ML_LIST" = "\"foo
   123
-baz\"" }  
+baz\"" }
             ')
           else
             # No support for clean multiline replacements without store/retrieve
@@ -751,6 +751,25 @@ baz fooz\"" }
       txn.any_failed?.should_not == nil
       @logs.first.level.should == :err
       @logs.first.message.include?(target).should == true
+    end
+  end
+
+  context "with commented file" do
+    let(:tmptarget) { aug_fixture("commented") }
+    let(:target) { tmptarget.path }
+
+    it "should create simple new entry" do
+      apply!(Puppet::Type.type(:shellvar).new(
+        :name     => "UMASK",
+        :value    => "0770",
+        :target   => target,
+        :provider => "augeas"
+      ))
+
+      augparse(target, "Shellvars.lns", '
+        { "#comment" = "UMASK sets the initial shell file creation mode mask.  See umask(1)." }
+        { "UMASK" = "0770" }
+      ')
     end
   end
 end


### PR DESCRIPTION
do not attempt to split strings on '=' that do not contain it.  Fixes variable without assignment in comments section causing an error #22