### PR TITLE
Remove identity from shellvar type

### DIFF
--- a/lib/puppet/type/shellvar.rb
+++ b/lib/puppet/type/shellvar.rb
@@ -178,27 +178,26 @@ Puppet::Type.newtype(:shellvar) do
   end
 
   def self.title_patterns
-    identity = lambda { |x| x }
     [
       [
         /^((\S+)\s+in\s+(\S+))$/,
         [
-          [ :name, identity ],
-          [ :variable, identity ],
-          [ :target, identity ]
+          [ :name ],
+          [ :variable ],
+          [ :target ]
         ]
       ],
       [
         /((\S+))/,
         [
-          [ :name, identity ],
-          [ :variable, identity ]
+          [ :name ],
+          [ :variable ]
         ]
       ],
       [
         /(.*)/,
         [
-          [ :name, identity ]
+          [ :name ]
         ]
       ]
     ]


### PR DESCRIPTION
When running `puppet generate types` (or `puppet generate types --environment <env>`) to ensure type isolation across environments we get the following error message:

> [...]/augeasproviders_shellvar/lib/puppet/type/shellvar.rb: title patterns that use procs are not supported.

According to this [Issue](https://tickets.puppetlabs.com/browse/MODULES-4505) this is caused returning the identity as second parameter, which seems to be deprecated. 

This PR simply fixes that issue for _augeasproviders_shellvar_
  