### PR TITLE
Fix title patterns to not use unsupported proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.3
+
+- Fix support for 'puppet generate types'
+- Added CentOS and OracleLinux to supported OS list
+
 ## 2.2.2
 
 - Upped supported Puppet versions to include Puppet 5

--- a/lib/puppet/type/shellvar.rb
+++ b/lib/puppet/type/shellvar.rb
@@ -178,27 +178,26 @@ Puppet::Type.newtype(:shellvar) do
   end
 
   def self.title_patterns
-    identity = lambda { |x| x }
     [
       [
         /^((\S+)\s+in\s+(\S+))$/,
         [
-          [ :name, identity ],
-          [ :variable, identity ],
-          [ :target, identity ]
+          [ :name ],
+          [ :variable ],
+          [ :target ]
         ]
       ],
       [
         /((\S+))/,
         [
-          [ :name, identity ],
-          [ :variable, identity ]
+          [ :name ],
+          [ :variable ]
         ]
       ],
       [
         /(.*)/,
         [
-          [ :name, identity ]
+          [ :name ]
         ]
       ]
     ]

--- a/lib/puppet/type/shellvar.rb
+++ b/lib/puppet/type/shellvar.rb
@@ -162,9 +162,9 @@ Puppet::Type.newtype(:shellvar) do
 
   newparam(:uncomment) do
     desc "Whether to remove commented value when found."
-    
+
     newvalues :true, :false
-    
+
     defaultto :false
 
     munge do |v|

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "herculesteam-augeasproviders_shellvar",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "author": "Dominic Cleal, Raphael Pinson",
   "summary": "Augeas-based shellvar type and provider for Puppet",
   "license": "Apache-2.0",
@@ -40,6 +40,22 @@
       "operatingsystemrelease": [
         "4",
         "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
         "6",
         "7"
       ]


### PR DESCRIPTION
This will resolve errors with `puppet generate types`

Example:
```
Error: /etc/puppetlabs/code/environments/production/modules/augeasproviders_shellvar/lib/puppet/type/shellvar.rb: title patterns that use procs are not supported.
```

https://tickets.puppetlabs.com/browse/MODULES-4505?focusedCommentId=418416&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-418416
https://github.com/treydock/puppet-module-keycloak/pull/21