### PR TITLE
Revert "Fix title patterns to not use unsupported proc (#27)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.4
+
+- Revert the 'puppet generate types' fix due to a discovery that it does not
+  work properly prior to puppet 4.10.4 due to a bug in puppet.
+
 ## 2.2.3
 
 - Fix support for 'puppet generate types'

--- a/lib/puppet/type/shellvar.rb
+++ b/lib/puppet/type/shellvar.rb
@@ -162,9 +162,9 @@ Puppet::Type.newtype(:shellvar) do
 
   newparam(:uncomment) do
     desc "Whether to remove commented value when found."
-
+    
     newvalues :true, :false
-
+    
     defaultto :false
 
     munge do |v|
@@ -178,26 +178,27 @@ Puppet::Type.newtype(:shellvar) do
   end
 
   def self.title_patterns
+    identity = lambda { |x| x }
     [
       [
         /^((\S+)\s+in\s+(\S+))$/,
         [
-          [ :name ],
-          [ :variable ],
-          [ :target ]
+          [ :name, identity ],
+          [ :variable, identity ],
+          [ :target, identity ]
         ]
       ],
       [
         /((\S+))/,
         [
-          [ :name ],
-          [ :variable ]
+          [ :name, identity ],
+          [ :variable, identity ]
         ]
       ],
       [
         /(.*)/,
         [
-          [ :name ]
+          [ :name, identity ]
         ]
       ]
     ]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "herculesteam-augeasproviders_shellvar",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "author": "Dominic Cleal, Raphael Pinson",
   "summary": "Augeas-based shellvar type and provider for Puppet",
   "license": "Apache-2.0",


### PR DESCRIPTION
At the time of release, we were not aware that there was a bug in Puppet
that caused this fix to not work prior to puppet 4.10.4.

This is a revert that will let us release a properly non-breaking
version and then bump the major version number denoting that the next
release has breaking changes.

This reverts commit 5aa572a6b126d219e97db9f2612f651eaa5462a7.