### PR TITLE
[WIP] Make tests pass with Puppet 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
-dist: precise
 sudo: required
 rvm:
-  - 2.1.9
   # Ruby with Puppet 5
   - 2.4.4
 notifications:
@@ -10,20 +8,13 @@ notifications:
    - raphael.pinson@camptocamp.com
 env:
 # base env
-  # Test Puppet 4
-  - PUPPET=4.0 RUBY_AUGEAS=0.5
-  # Test Oldest Puppet, Inc. supported Puppet
-  - PUPPET=4.10.4 RUBY_AUGEAS=0.5 FORGE_PUBLISH=true
+  # Test latest Puppet 5 version
+  - PUPPET=5.5 RUBY_AUGEAS=0.5 FORGE_PUBLISH=true
   # Test latest Puppet version
-  - PUPPET=5.5 RUBY_AUGEAS=0.5
+  - PUPPET=6 RUBY_AUGEAS=0.5
 
 matrix:
   fast_finish: true
-  exclude:
-    # base exclude
-    # No support for Ruby 2.1.9 in Puppet 5
-    - rvm: 2.1.9
-      env: PUPPET=5.5 RUBY_AUGEAS=0.5
 
 install:
   - "travis_retry ./.travis.sh"
@@ -41,5 +32,5 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    rvm: 2.1.9
+    rvm: 2.4.4
     condition: "$FORGE_PUBLISH = true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.0
+
+- Add support for Puppet 6
+- Deprecate support for Puppet < 5
+- Update supported OSes in metadata.json
+
 ## 3.0.0
 
 - Fix support for 'puppet generate types'

--- a/metadata.json
+++ b/metadata.json
@@ -1,45 +1,40 @@
 {
   "name": "herculesteam-augeasproviders_shellvar",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Dominic Cleal, Raphael Pinson",
   "summary": "Augeas-based shellvar type and provider for Puppet",
   "license": "Apache-2.0",
   "source": "https://github.com/hercules-team/augeasproviders_shellvar",
-  "project_page": "http://augeasproviders.com",
+  "project_page": "https://github.com/hercules-team/augeasproviders_shellvar",
   "issues_url": "https://github.com/hercules-team/augeasproviders_shellvar/issues",
   "description": "This module provides a type/provider for shell files using the Augeas configuration API library.",
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">=2.1.0 <3.0.0"
+      "version_requirement": ">=2.4.0 <3.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "12.10",
         "14.04",
-        "14.10",
-        "15.10",
-        "16.04"
+        "16.04",
+        "18.04",
+        "18.10"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "4",
-        "5",
         "6",
         "7"
       ]
@@ -47,8 +42,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "4",
-        "5",
         "6",
         "7"
       ]
@@ -64,7 +57,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ]
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,10 +34,16 @@ Puppet[:modulepath] = File.join(dir, 'fixtures', 'modules')
 # ticket https://tickets.puppetlabs.com/browse/MODULES-823
 #
 ver = Gem::Version.new(Puppet.version.split('-').first)
-if Gem::Requirement.new("~> 2.7.20") =~ ver || Gem::Requirement.new("~> 3.0.0") =~ ver || Gem::Requirement.new("~> 3.5") =~ ver || Gem::Requirement.new("~> 4.0") =~ ver || Gem::Requirement.new("~> 5.0") =~ ver
-  puts "augeasproviders: setting Puppet[:libdir] to work around broken type autoloading"
-  # libdir is only a single dir, so it can only workaround loading of one external module
-  Puppet[:libdir] = "#{Puppet[:modulepath]}/augeasproviders_core/lib"
+if ver >= Gem::Version.new("2.7.20")
+    puts "augeasproviders: setting $LOAD_PATH to work around broken type autoloading"
+    Puppet.initialize_settings
+    $LOAD_PATH.unshift(
+        dir,
+        File.join(dir, 'fixtures/modules/augeasproviders_core/spec/lib'),
+        File.join(dir, 'fixtures/modules/augeasproviders_core/lib')
+    )
+
+    $LOAD_PATH.unshift(File.join(dir, '..', 'lib'))
 end
 
 # Load all shared contexts and shared examples


### PR DESCRIPTION
This fixes tests for Puppet 6, as discussed in https://github.com/hercules-team/augeasproviders_core/issues/10

We need to decide if we:

* add `augeas_core` as a dependency for the modules to get the `augeas` feature
* provide our own `augeas` feature in the `augeasproviders_core` module