### PR TITLE
Fix unquote when comment value is nil

### DIFF
--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -194,7 +194,13 @@ Puppet::Type.type(:shellvar).provide(:augeas, parent: Puppet::Type.type(:augeasp
       commented_values = []
       unless commented.empty?
         commented_values = if aug.get(commented.first).include?('=')
-                             unquoteit(aug.get(commented.first).split('=')[1]).split(' ')
+                             value = aug.get(commented.first).split('=')[1]
+                             # check if the value after the = is nil otherwise
+                             if value.nil?
+                               value
+                             else
+                               unquoteit(value).split(' ')
+                             end
                            else
                              unquoteit(aug.get(commented.first)).split(' ')
                            end

--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -195,12 +195,8 @@ Puppet::Type.type(:shellvar).provide(:augeas, parent: Puppet::Type.type(:augeasp
       unless commented.empty?
         commented_values = if aug.get(commented.first).include?('=')
                              value = aug.get(commented.first).split('=')[1]
-                             # check if the value after the = is nil otherwise
-                             if value.nil?
-                               value
-                             else
-                               unquoteit(value).split(' ')
-                             end
+                             return nil if value.nil?
+                             unquoteit(value).split(' ')
                            else
                              unquoteit(aug.get(commented.first)).split(' ')
                            end


### PR DESCRIPTION
  The provider is getting an error in the create module
  when a comment exists for the variable and has an '='
  but no value following it.
  ie # XYZ=
  It attempts to  preform a split on a nil value and errors out.
  This adds a check for nil when trying to set possible values
  from the comment.